### PR TITLE
Add ctre to base pyfrc install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ robotpy-hal-sim>=2017.1.1,<2018.0.0
 
 robotpy-installer>=2017.0.0,<2018.0.0
 
+robotpy-ctre>=2018.0.0,<2018.0.0
+
 # Not really a requirement, but this is on the robot, so just install by default
 robotpy-wpilib-utilities>=2017.0.0,<2018.0.0
 


### PR DESCRIPTION
It just seems reasonable to include it. Makes it easier to just install pyfrc and be able to program.