### PR TITLE
Enable all warnings when testing

### DIFF
--- a/lib/pyfrc/mains/cli_test.py
+++ b/lib/pyfrc/mains/cli_test.py
@@ -1,6 +1,7 @@
 
 import os
 import inspect
+import warnings
 import sys
 
 from os.path import abspath, dirname, exists, join
@@ -40,6 +41,10 @@ class PyFrcTest:
         from .. import config
         config.mode = 'test'
         config.coverage_mode = options.coverage_mode
+
+        # Enable all warnings - see PEP 565
+        if not sys.warnoptions:
+            warnings.simplefilter('default')
         
         return self.run_test(options.pytest_args, robot_class, options.builtin, **static_options)
         


### PR DESCRIPTION
Let's… not merge this until we actually squash all our DeprecationWarnings, otherwise the test logs won't be fun to read.