### PR TITLE
Change getargspec to getfullargspec in docstring_test

### DIFF
--- a/lib/pyfrc/tests/docstring_test.py
+++ b/lib/pyfrc/tests/docstring_test.py
@@ -54,7 +54,7 @@ def check_function(parent, fn, errors):
     
     elif pedantic_docstrings:
         # find the list of parameters
-        args, varargs, keywords, defaults = inspect.getargspec(fn)
+        args, varargs, keywords, defaults = inspect.getfullargspec(fn)
         if len(args) > 0 and args[0] == 'self':
             del args[0]
             


### PR DESCRIPTION
`inspect.getargspec()` is deprecated and fails with some new constructs (detailed in #95).

This PR fixes #95.