### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 env:
   - RUNCOVERAGE=1 ROBOTPY_NO_DEPS=1
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 # command to install dependencies

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(name='pyfrc',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development'


### PR DESCRIPTION
wpilib requires Python 3.5+ now, so.

Ref: robotpy/robotpy-wpilib#355