### PR TITLE
Update dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 pytest>=2.8.0
 pynetconsole>=1.3.1
 
-wpilib>=2017.1.1,<2018.0.0
-robotpy-hal-sim>=2017.1.1,<2018.0.0
+wpilib>=2018.0.0,<2019.0.0
+robotpy-hal-sim>=2018.0.0,<2019.0.0
 
-robotpy-installer>=2017.0.0,<2018.0.0
+robotpy-installer>=2018.0.0,<2019.0.0
 
 # Not really a requirement, but this is on the robot, so just install by default
-robotpy-wpilib-utilities>=2017.0.0,<2018.0.0
+robotpy-wpilib-utilities>=2018.0.0,<2019.0.0
 
 # coverage isn't in here because it requires an installed compiler, which
 # many students may not have installed


### PR DESCRIPTION
Requirements now use the 2018 version of all packages instead of the 2017 versions.