### PR TITLE
Add linear_deadzone function to aid with motor simulation

### DIFF
--- a/lib/pyfrc/physics/drivetrains.py
+++ b/lib/pyfrc/physics/drivetrains.py
@@ -15,8 +15,54 @@
     estimate the speed of your robot accurately.
 '''
 import math
+
+def linear_deadzone(deadzone):
+    '''
+        Real motors won't actually move unless you give them some minimum amount
+        of input. This computes an output speed for a motor and causes it to
+        'not move' if the input isn't high enough. Additionally, the output is
+        adjusted linearly to compensate.
+        
+        Example: For a deadzone of 0.2:
+        
+        * Input of 0.0 will result in 0.0
+        * Input of 0.2 will result in 0.0
+        * Input of 0.3 will result in ~0.12
+        * Input of 1.0 will result in 1.0
+        
+        This returns a function that computes the deadzone. You should pass the
+        returned function to one of the drivetrain simulation functions as the
+        ``deadzone`` parameter.
+        
+        Here's an example usage:
+        
+            from pyfrc.physics import drivetrains
+        
+            class PhysicsEngine:
+                
+                def __init__(self, physics_controller):
+                    self.drivetrain_deadzone = drivetrains.linear_deadzone(0.2)
+                    
+                def update_sim(self, hal_data, now, tm_diff):
+                    # TODO: get motor values from hal_data
+                    speed_rotation = drivetrains.two_motor_drivetrain(l_motor, r_motor,
+                                                                      deadzone=self.drivetrain_deadzone)
+        
+        :param motor_input: The motor input (between -1 and 1)
+        :param deadzone: Minimum input required for the motor to move (between 0 and 1)
+    '''
+    assert 0.0 < deadzone < 1.0
+    scale_param = 1.0 - deadzone
+    def _linear_deadzone(motor_input):
+        abs_motor_input = abs(motor_input)
+        if abs_motor_input < deadzone:
+            return 0.0
+        else:
+            return math.copysign((abs_motor_input - deadzone) / scale_param, motor_input)
     
-def two_motor_drivetrain(l_motor, r_motor, x_wheelbase=2, speed=5):
+    return _linear_deadzone
+    
+def two_motor_drivetrain(l_motor, r_motor, x_wheelbase=2, speed=5, deadzone=None):
     '''
         Two center-mounted motors with a simple drivetrain. The 
         motion equations are as follows::
@@ -38,9 +84,14 @@ def two_motor_drivetrain(l_motor, r_motor, x_wheelbase=2, speed=5):
         :param r_motor:    Right motor value (-1 to 1); 1 is forward
         :param x_wheelbase: The distance in feet between right and left wheels.
         :param speed:      Speed of robot in feet per second (see above)
+        :param deadzone:   A function that adjusts the output of the motor (see :func:`linear_deadzone`)
         
         :returns: speed of robot (ft/s), clockwise rotation of robot (radians/s)
     '''
+    
+    if deadzone:
+        l_motor = deadzone(l_motor)
+        r_motor = deadzone(r_motor)
     
     l = -l_motor * speed
     r = r_motor * speed
@@ -52,7 +103,7 @@ def two_motor_drivetrain(l_motor, r_motor, x_wheelbase=2, speed=5):
     return fwd, rcw
 
 
-def four_motor_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2, speed=5):
+def four_motor_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2, speed=5, deadzone=None):
     '''
         Four motors, each side chained together. The motion equations are
         as follows::
@@ -76,9 +127,16 @@ def four_motor_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2,
         :param rf_motor:   Right front motor value (-1 to 1); 1 is forward
         :param x_wheelbase: The distance in feet between right and left wheels.
         :param speed:      Speed of robot in feet per second (see above)
+        :param deadzone:   A function that adjusts the output of the motor (see :func:`linear_deadzone`)
         
         :returns: speed of robot (ft/s), clockwise rotation of robot (radians/s)
     '''
+    
+    if deadzone:
+        lf_motor = deadzone(lf_motor)
+        lr_motor = deadzone(lr_motor)
+        rf_motor = deadzone(rf_motor)
+        rr_motor = deadzone(rr_motor)
     
     l = -(lf_motor + lr_motor) * 0.5 * speed
     r = (rf_motor + rr_motor) * 0.5 * speed
@@ -90,7 +148,7 @@ def four_motor_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2,
     return fwd, rcw
 
 
-def mecanum_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2, y_wheelbase=3, speed=5):
+def mecanum_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2, y_wheelbase=3, speed=5, deadzone=None):
     '''
         Four motors, each with a mechanum wheel attached to it.
         
@@ -107,6 +165,7 @@ def mecanum_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2, y_
         :param x_wheelbase: The distance in feet between right and left wheels.
         :param y_wheelbase: The distance in feet between forward and rear wheels.
         :param speed:      Speed of robot in feet per second (see above)
+        :param deadzone:   A function that adjusts the output of the motor (see :func:`linear_deadzone`)
         
         :returns: Speed of robot in x (ft/s), Speed of robot in y (ft/s), 
                   clockwise rotation of robot (radians/s)
@@ -123,6 +182,12 @@ def mecanum_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2, y_
     #
     # omega is
     # [lf lr rr rf]
+    
+    if deadzone:
+        lf_motor = deadzone(lf_motor)
+        lr_motor = deadzone(lr_motor)
+        rf_motor = deadzone(rf_motor)
+        rr_motor = deadzone(rr_motor)
 
     # Calculate speed of each wheel
     lr = lr_motor * speed
@@ -140,7 +205,7 @@ def mecanum_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, x_wheelbase=2, y_
     
     return Vx, Vy, Vw
     
-def four_motor_swerve_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, lr_angle, rr_angle, lf_angle, rf_angle, x_wheelbase=2, y_wheelbase=2, speed=5):
+def four_motor_swerve_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, lr_angle, rr_angle, lf_angle, rf_angle, x_wheelbase=2, y_wheelbase=2, speed=5, deadzone=None):
     '''
         Four motors that can be rotated in any direction
         
@@ -160,10 +225,18 @@ def four_motor_swerve_drivetrain(lr_motor, rr_motor, lf_motor, rf_motor, lr_angl
         :param x_wheelbase: The distance in feet between right and left wheels.
         :param y_wheelbase: The distance in feet between forward and rear wheels.
         :param speed:      Speed of robot in feet per second (see above)
+        :param deadzone:   A function that adjusts the output of the motor (see :func:`linear_deadzone`)
         
         :returns: Speed of robot in x (ft/s), Speed of robot in y (ft/s), 
                   clockwise rotation of robot (radians/s)
     '''
+    
+    if deadzone:
+        lf_motor = deadzone(lf_motor)
+        lr_motor = deadzone(lr_motor)
+        rf_motor = deadzone(rf_motor)
+        rr_motor = deadzone(rr_motor)
+    
     # Calculate speed of each wheel
     lr = lr_motor * speed
     rr = rr_motor * speed


### PR DESCRIPTION
- Fixes #79

This is a bit weird because it returns a function that computes the deadzone... an alternative approach would be requiring the user to compute the deadzone on each motor, and then pass the new values to the sim (thus not requiring any change to the drivetrain functions). This seems simpler?