### PR TITLE
Cleanly destroy pygame

### DIFF
--- a/lib/pyfrc/sim/pygame_joysticks.py
+++ b/lib/pyfrc/sim/pygame_joysticks.py
@@ -11,6 +11,10 @@ class UsbJoysticks(object):
         self.joysticks = self.getUsbJoystickList()
         self.initJoystickList(self.joysticks)
 
+    def close(self):
+        pygame.display.quit()
+        pygame.quit()
+
     def getUsbJoystickList(self):
         joysticks = []
 

--- a/lib/pyfrc/sim/ui.py
+++ b/lib/pyfrc/sim/ui.py
@@ -79,6 +79,8 @@ class SimUI(object):
         self.root = tk.Tk()
         self.root.wm_title("PyFRC Robot Simulator v%s" % __version__)
 
+        self.root.protocol("WM_DELETE_WINDOW", self._delete_window)
+
         # setup mode switch
         frame = tk.Frame(self.root)
         frame.pack(side=tk.TOP, anchor=tk.W)
@@ -129,6 +131,11 @@ class SimUI(object):
             pass
 
         self.timer_fired()
+
+    def _delete_window(self):
+        self.root.destroy()
+        if self.usb_joysticks is not None:
+            self.usb_joysticks.close()
 
     def _setup_widgets(self, frame):
 


### PR DESCRIPTION
- This doesn't really completely work, but it's a lot better than it was on OSX

... It tends to crash on exit with Windows/OSX, would be nice to figure out why that's happening.