### PR TITLE
Bug calculating delta x, y in TankModel

### DIFF
--- a/lib/pyfrc/physics/tankmodel.py
+++ b/lib/pyfrc/physics/tankmodel.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('pyfrc.physics')
 _bumper_length =    3.25 * units.inch
 
 _kitbot_wheelbase = 21.0 * units.inch
-_kitbot_width =     2.0 * units.inch + _bumper_length*2
+_kitbot_width =     _kitbot_wheelbase + _bumper_length*2
 _kitbot_length =    30.0 * units.inch + _bumper_length*2
 
 _inertia_units =    (units.foot ** 2) * units.pound
@@ -388,8 +388,8 @@ class TankModel:
             distance = velocity * tm_diff
             turn = rotation * tm_diff
             
-            x += distance * math.cos(turn)
-            y += distance * math.sin(turn)
+            x += distance * math.cos(angle)
+            y += distance * math.sin(angle)
             angle += turn
         
         return x, y, angle

--- a/tests/test_tankmodel.py
+++ b/tests/test_tankmodel.py
@@ -2,34 +2,44 @@
 # import pytest
 from pyfrc.physics import tankmodel, motor_cfgs
 from pyfrc.physics.units import units
-from math import degrees, radians
+from math import degrees, radians, isclose
 
 
 def test_tankdrive_get_distance():
+    '''Test TankModel.get_distance() by driving in a quarter circle.
+    If the turn angle is 90deg, then x should equal y. get_distance() runs in little steps,
+    so multiple calls should be equivalent to a single call'''
+
+    # just use the default robot
     tank = tankmodel.TankModel.theory(motor_cfgs.MOTOR_CFG_CIM,
                                       robot_mass=90*units.lbs,
                                       gearing=10.71,
                                       nmotors=2,
                                       x_wheelbase=2.0*units.feet,
                                       wheel_diameter=6*units.inch)
+    # slight turn to the right
     l_motor = -1.0
     r_motor = 0.9
-    # get the motors up to speed
+
+    # get the motors up to speed, so that subsequent calls produce the same result
     tank.get_distance(l_motor, r_motor, 2.0)
 
-    # figure out how long to go to get 90deg
+    # figure out how much time is needed to turn 90 degrees
     angle = 0.0
+    angle_target = radians(90.0)
     total_time = 0.0
     tstep = 0.01
-    while angle < radians(90.0):
+
+    while angle < angle_target:
         result = tank.get_distance(l_motor, r_motor, tstep)
         angle += result[2]
         total_time += tstep
 
-    print('time needed', total_time)
+    # print('time needed', total_time)
 
+    # OK, now do it in a single call. x should equal y
     result = tank.get_distance(l_motor, r_motor, total_time)
-    print(result[0], result[1], degrees(result[2]), result[0]/result[1])
-    assert abs(degrees(result[2]) - 90.0) < 2.0
-    assert abs(result[0] / result[1] - 1.0) < 0.01
+    # print(result[0], result[1], degrees(result[2]), result[0]/result[1])
+    assert isclose(degrees(result[2]), 90.0, abs_tol=2.0), 'Single call did not produce a 90deg turn'
+    assert isclose(result[0], result[1], rel_tol=0.01), 'For 90deg turn, x and y should be the same'
     return

--- a/tests/test_tankmodel.py
+++ b/tests/test_tankmodel.py
@@ -2,7 +2,7 @@
 # import pytest
 from pyfrc.physics import tankmodel, motor_cfgs
 from pyfrc.physics.units import units
-from math import degrees, radians, isclose
+import math
 
 
 def test_tankdrive_get_distance():
@@ -26,7 +26,7 @@ def test_tankdrive_get_distance():
 
     # figure out how much time is needed to turn 90 degrees
     angle = 0.0
-    angle_target = radians(90.0)
+    angle_target = math.pi / 2.0 # 90 degrees
     total_time = 0.0
     tstep = 0.01
 
@@ -40,6 +40,6 @@ def test_tankdrive_get_distance():
     # OK, now do it in a single call. x should equal y
     result = tank.get_distance(l_motor, r_motor, total_time)
     # print(result[0], result[1], degrees(result[2]), result[0]/result[1])
-    assert isclose(degrees(result[2]), 90.0, abs_tol=2.0), 'Single call did not produce a 90deg turn'
-    assert isclose(result[0], result[1], rel_tol=0.01), 'For 90deg turn, x and y should be the same'
+    assert math.isclose(result[2], angle_target, abs_tol=2.0), 'Single call should produce a 90deg turn'
+    assert math.isclose(result[0], result[1], rel_tol=0.01), 'For 90deg turn, x and y should be the same'
     return

--- a/tests/test_tankmodel.py
+++ b/tests/test_tankmodel.py
@@ -1,0 +1,35 @@
+
+# import pytest
+from pyfrc.physics import tankmodel, motor_cfgs
+from pyfrc.physics.units import units
+from math import degrees, radians
+
+
+def test_tankdrive_get_distance():
+    tank = tankmodel.TankModel.theory(motor_cfgs.MOTOR_CFG_CIM,
+                                      robot_mass=90*units.lbs,
+                                      gearing=10.71,
+                                      nmotors=2,
+                                      x_wheelbase=2.0*units.feet,
+                                      wheel_diameter=6*units.inch)
+    l_motor = -1.0
+    r_motor = 0.9
+    # get the motors up to speed
+    tank.get_distance(l_motor, r_motor, 2.0)
+
+    # figure out how long to go to get 90deg
+    angle = 0.0
+    total_time = 0.0
+    tstep = 0.01
+    while angle < radians(90.0):
+        result = tank.get_distance(l_motor, r_motor, tstep)
+        angle += result[2]
+        total_time += tstep
+
+    print('time needed', total_time)
+
+    result = tank.get_distance(l_motor, r_motor, total_time)
+    print(result[0], result[1], degrees(result[2]), result[0]/result[1])
+    assert abs(degrees(result[2]) - 90.0) < 2.0
+    assert abs(result[0] / result[1] - 1.0) < 0.01
+    return

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -8,3 +8,4 @@ git+git://github.com/robotpy/robotpy-wpilib-utilities.git
 
 coverage
 pytest>=2.8
+pint


### PR DESCRIPTION
My first pull request for RobotPy, so hope this is OK.

TankModel.get_distance() should use "angle" when computing the change in x and y. It incorrectly used "turn", which is the increment for "angle".  

I added a unit test for TankModel which makes a 90degree turn for the robot. If you do that in a single call to get_distance(), the old code produces a large change in x and small in y. The updated code has them close to equal.

One other small change: I changed the default robot width (variable _kitbot_width in TankModel) because it was setting a 2 inch wide robot.