### PR TITLE
Add button to reset robot position

### DIFF
--- a/lib/pyfrc/physics/core.py
+++ b/lib/pyfrc/physics/core.py
@@ -123,9 +123,12 @@ class PhysicsInterface:
         self._lock = threading.Lock()
         
         # These are in units of feet relative to the field
-        self.x = config_obj['pyfrc']['robot']['starting_x']
-        self.y = config_obj['pyfrc']['robot']['starting_y']
-        self.angle = math.radians(config_obj['pyfrc']['robot']['starting_angle'])
+        self.start_x = config_obj['pyfrc']['robot']['starting_x']
+        self.start_y = config_obj['pyfrc']['robot']['starting_y']
+        self.start_angle = math.radians(config_obj['pyfrc']['robot']['starting_angle'])
+        self.x = self.start_x
+        self.y = self.start_y
+        self.angle = self.start_angle
         
         self.robot_w = config_obj['pyfrc']['robot']['w']
         self.robot_l = config_obj['pyfrc']['robot']['l']
@@ -354,4 +357,12 @@ class PhysicsInterface:
         '''
         return self.vx, self.vy, self.angle
         
-    
+    def reset_position(self):
+        with self._lock:
+            self.vx += self.start_x - self.x
+            self.vy += self.start_y - self.y
+            self._update_gyros(-self.angle)
+
+            self.x = self.start_x
+            self.y = self.start_y
+            self.angle = self.start_angle

--- a/lib/pyfrc/physics/core.py
+++ b/lib/pyfrc/physics/core.py
@@ -361,7 +361,7 @@ class PhysicsInterface:
         with self._lock:
             self.vx += self.start_x - self.x
             self.vy += self.start_y - self.y
-            self._update_gyros(-self.angle)
+            self._update_gyros(self.start_angle - self.angle)
 
             self.x = self.start_x
             self.y = self.start_y

--- a/lib/pyfrc/physics/core.py
+++ b/lib/pyfrc/physics/core.py
@@ -359,8 +359,15 @@ class PhysicsInterface:
         
     def reset_position(self):
         with self._lock:
-            self.vx += self.start_x - self.x
-            self.vy += self.start_y - self.y
+            # move the robot backwards to reach its start position
+            # the change in rotation will be applied before the change in position
+            c = math.cos(self.start_angle)
+            s = math.sin(self.start_angle)
+            move_x = self.start_x - self.x  # in field coordinates
+            move_y = self.start_y - self.y
+            # convert to robot coordinates...
+            self.vx += move_x * c + move_y * s
+            self.vy += -move_x * s + move_y * c
             self._update_gyros(self.start_angle - self.angle)
 
             self.x = self.start_x

--- a/lib/pyfrc/sim/ui.py
+++ b/lib/pyfrc/sim/ui.py
@@ -406,6 +406,13 @@ class SimUI(object):
             Tooltip.create(self.gamedatabox, "Use this selection box to simulate game specific data")
             gamedata.pack(side=tk.TOP)
 
+        def _reset_robot():
+            for robot in self.manager.robots:
+                robot.physics_controller.reset_position()
+
+        button = tk.Button(ctrl_frame, text="Reset Robot", command=_reset_robot)
+        button.pack(side=tk.TOP)
+
         ctrl_frame.pack(side=tk.LEFT, fill=tk.Y)
     
     def _render_pcm(self):


### PR DESCRIPTION
This would be useful for testing multiple autonomous sequences.

It might be nice to show the popup dialog that appears when you have multiple starting positions defined, so you could easily switch between starting positions, but I wasn't sure how the PhysicsInterface could access that information.