### PR TITLE
pyfrc.tests: Silence warnings

### DIFF
--- a/lib/pyfrc/tests/basic.py
+++ b/lib/pyfrc/tests/basic.py
@@ -31,6 +31,7 @@ def test_autonomous(control, fake_time, robot, gamedata):
     assert int(fake_time.get()) == 15
 
 
+@pytest.mark.filterwarnings("ignore")
 def test_disabled(control, fake_time, robot):
     """Runs disabled mode by itself"""
 
@@ -42,6 +43,7 @@ def test_disabled(control, fake_time, robot):
     assert int(fake_time.get()) == 5
 
 
+@pytest.mark.filterwarnings("ignore")
 def test_operator_control(control, fake_time, robot):
     """Runs operator control mode by itself"""
 
@@ -53,6 +55,7 @@ def test_operator_control(control, fake_time, robot):
     assert int(fake_time.get()) == 15
 
 
+@pytest.mark.filterwarnings("ignore")
 def test_practice(control, fake_time, robot):
     """Runs through the entire span of a practice match"""
 


### PR DESCRIPTION
This silences warnings for the disabled, teleop and practice tests to avoid showing the same warnings to users multiple times.

Open questions:

- Should we give the autonomous tests the same treatment? I'm slightly leaning towards no, in case teams use deprecated things conditionally on the game-specific message.
- Should the "practice mode" test get the same treatment too? The fuzz tests will also loop through all the modes, so this might be a good idea.