### PR TITLE
Allow joysticks to be controlled outside teleop

### DIFF
--- a/lib/pyfrc/configloader.py
+++ b/lib/pyfrc/configloader.py
@@ -29,7 +29,16 @@ _field_defaults = {
         "image": join(_field_root, "2019-field.gif"),
         "auto_joysticks": True,
     },
-    "default": {"h": 1, "w": 1, "px_per_ft": 10, "image": None, "auto_joysticks": True},
+    "default": {
+        "h": 1,
+        "w": 1,
+        "px_per_ft": 10,
+        "image": None,
+        "auto_joysticks": False,
+        # The DS sends joystick data in disabled mode. However,
+        # most people will never use this. Let advanced teams mess around.
+        "disabled_joysticks": False,
+    },
 }
 
 _default_year = "2019"
@@ -121,6 +130,9 @@ def _load_config(robot_path):
     )
     config_obj["pyfrc"]["field"].setdefault(
         "auto_joysticks", defaults.get("auto_joysticks", False)
+    )
+    config_obj["pyfrc"]["field"].setdefault(
+        "disabled_joysticks", defaults.get("disabled_joysticks", False)
     )
     assert isinstance(config_obj["pyfrc"]["game_specific_messages"], (list, type(None)))
 

--- a/lib/pyfrc/sim/ui.py
+++ b/lib/pyfrc/sim/ui.py
@@ -17,7 +17,7 @@ from hal_impl.data import hal_data
 
 from .. import __version__
 from .field.field import RobotField
-from .ui_widgets import CheckButtonWrapper, PanelIndicator, Tooltip, ValueWidget
+from .ui_widgets import PanelIndicator, Tooltip, ValueWidget
 
 from pkg_resources import iter_entry_points
 
@@ -60,7 +60,7 @@ def configure_starting_position(config_obj):
 
 
 class SimUI(object):
-    def __init__(self, manager, fake_time, config_obj):
+    def __init__(self, manager, fake_time, config_obj: dict) -> None:
         """
             initializes all default values and creates
             a board, waits for run() to be called
@@ -701,12 +701,13 @@ class SimUI(object):
 
         self.mode_start_tm = self.fake_time.get()
 
-        # this is not strictly true... a robot can actually receive joystick
-        # commands from the driver station in disabled mode. However, most
-        # people aren't going to use that functionality...
-        controls_disabled = (
-            False if mode == self.manager.MODE_OPERATOR_CONTROL else True
-        )
+        if mode == self.manager.MODE_AUTONOMOUS:
+            controls_disabled = not self.config_obj["pyfrc"]["field"]["auto_joysticks"]
+        else:
+            controls_disabled = (
+                not self.config_obj["pyfrc"]["field"]["disabled_joysticks"]
+                and mode == self.manager.MODE_DISABLED
+            )
         state = tk.DISABLED if controls_disabled else tk.NORMAL
 
         for axes, buttons, povs in self.joysticks:


### PR DESCRIPTION
This allows for joystick inputs in autonomous (configurable) and test.

This also adds a new `disabled_joysticks` to the config (default false)
to allow advanced teams to send joystick inputs in disabled mode.

Also set the default (non-2019) `auto_joysticks` to false.

Fixes: #143