### PR TITLE
Add Github Action to bump requirements

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,43 @@
+---
+name: bump
+
+on: [repository_dispatch]
+
+jobs:
+  bump:
+    if: github.event_name == 'repository_dispatch' && github.event.action == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Information
+      run: |
+        echo "'${{ github.event.action }}' received from '${{ github.event.client_payload.repository }}'"
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        fetch-depth: 0
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install Dependencies
+      run: |
+        pip install gitpython
+
+    - name: Bump Requirements
+      run: |
+        python update_req.py '${{ github.event.client_payload.repository }}' '${{ github.event.client_payload.package_name }}'
+
+    - name: Push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "Github Action"
+        git add requirements.txt
+        git commit -m "Bump '${{ github.event.client_payload.package_name }}' dependency"
+        git push
+
+    - name: Bump Version and push Tag
+      uses: anothrNick/github-tag-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+        DEFAULT_BUMP: patch
+        WITH_V: false

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Information
       run: |
-        echo "'${{ github.event.action }}' received from '${{ github.event.client_payload.repository }}'"
+        echo "Version update for ${{ github.event.client_payload.package_name }} -> ${{ github.event.client_payload.package_version }} requested"
     - uses: actions/checkout@v2
       with:
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
@@ -19,13 +19,9 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Install Dependencies
-      run: |
-        pip install gitpython
-
     - name: Bump Requirements
       run: |
-        python update_req.py '${{ github.event.client_payload.repository }}' '${{ github.event.client_payload.package_name }}'
+        python update_req.py '${{ github.event.client_payload.package_name }}' '${{ github.event.client_payload.package_version }}'
 
     - name: Push changes
       run: |

--- a/update_req.py
+++ b/update_req.py
@@ -1,5 +1,6 @@
 import sys
 
+
 def main():
     package_name = sys.argv[1]  # Ex. robotpy/robotpy-wpilib
     package_version = sys.argv[2]  # Ex. wpilib
@@ -61,6 +62,7 @@ def getCurrentVersion(line: str):
     )  # remove newlines, tabs and spaces
     return v
 
+
 def getNextMajorVersion(curr_version: str):
     version = curr_version.split(".")
     version[0] = str(int(version[0]) + 1)
@@ -70,6 +72,7 @@ def getNextMajorVersion(curr_version: str):
 
     next_major = ".".join(version)
     return next_major
+
 
 if __name__ == "__main__":
     main()

--- a/update_req.py
+++ b/update_req.py
@@ -1,0 +1,83 @@
+import sys
+import git
+
+
+def main():
+    repo_name = sys.argv[1]  # Ex. robotpy/robotpy-wpilib
+    repo_path = "https://github.com/" + repo_name + ".git"
+    package_name = sys.argv[2]  # Ex. wpilib
+
+    print("Repository Name:", repo_name)
+    print("Repository Path:", repo_path)
+    print("Package Name:", package_name)
+
+    tag = git.Repo.clone_from(repo_path, "./temp", branch="master").git.describe(
+        "--tags", "--abbrev=0"
+    )
+
+    lower_bound = tag
+
+    print("Latest Version:", lower_bound)
+
+    version = tag.split(".")
+
+    for i in range(len(version)):
+        if i == 0:
+            version[i] = str(int(version[i]) + 1)
+        else:
+            version[i] = "0"
+
+    upper_bound = ".".join(version)
+
+    print("Next Major Version:", upper_bound)
+
+    file_data = None
+    with open("requirements.txt", "r") as file:
+        file_data = file.readlines()
+
+    line_idx = None
+
+    for i in range(len(file_data)):
+        if file_data[i].find(package_name + ">=") == 0:
+            line_idx = i
+
+    if line_idx is not None:
+        print("Package found in requirements.txt")
+
+        if getCurrentVersion(file_data[line_idx]) == lower_bound:
+            print(
+                "Package is already at the latest version (based on git tags). It was not updated."
+            )
+            exit(1)
+
+        file_data[line_idx] = "{}>={},<{}\n".format(
+            package_name, lower_bound, upper_bound
+        )
+    else:
+        print("Package not found in requirements.txt")
+        exit(1)
+
+    print("Rewriting Requirements")
+    with open("requirements.txt", "w") as file:
+        file.writelines(file_data)
+    print("Done")
+
+    exit(0)
+
+
+def getCurrentVersion(line: str):
+    stripped_line = line.strip("\r\n\t ")  # remove newlines, tabs and spaces
+
+    v_start = stripped_line.find(">=") + 2
+    v_end = stripped_line.find(",")
+    if v_end == -1:
+        v_end = len(stripped_line)
+
+    v = stripped_line[v_start:v_end].strip(
+        "\r\n\t "
+    )  # remove newlines, tabs and spaces
+    return v
+
+
+if __name__ == "__main__":
+    main()

--- a/update_req.py
+++ b/update_req.py
@@ -1,42 +1,25 @@
 import sys
-import git
-
 
 def main():
-    repo_name = sys.argv[1]  # Ex. robotpy/robotpy-wpilib
-    repo_path = "https://github.com/" + repo_name + ".git"
-    package_name = sys.argv[2]  # Ex. wpilib
+    package_name = sys.argv[1]  # Ex. robotpy/robotpy-wpilib
+    package_version = sys.argv[2]  # Ex. wpilib
 
-    print("Repository Name:", repo_name)
-    print("Repository Path:", repo_path)
     print("Package Name:", package_name)
+    print("Package Version:", package_version)
 
-    tag = git.Repo.clone_from(repo_path, "./temp", branch="master").git.describe(
-        "--tags", "--abbrev=0"
-    )
-
-    lower_bound = tag
-
+    lower_bound = package_version
     print("Latest Version:", lower_bound)
 
-    version = tag.split(".")
-
-    for i in range(len(version)):
-        if i == 0:
-            version[i] = str(int(version[i]) + 1)
-        else:
-            version[i] = "0"
-
-    upper_bound = ".".join(version)
-
+    upper_bound = getNextMajorVersion(lower_bound)
     print("Next Major Version:", upper_bound)
 
+    # Read requirements
     file_data = None
     with open("requirements.txt", "r") as file:
         file_data = file.readlines()
 
+    # Find desired requirement
     line_idx = None
-
     for i in range(len(file_data)):
         if file_data[i].find(package_name + ">=") == 0:
             line_idx = i
@@ -78,6 +61,15 @@ def getCurrentVersion(line: str):
     )  # remove newlines, tabs and spaces
     return v
 
+def getNextMajorVersion(curr_version: str):
+    version = curr_version.split(".")
+    version[0] = str(int(version[0]) + 1)
+
+    for i in range(1, len(version)):
+        version[i] = "0"
+
+    next_major = ".".join(version)
+    return next_major
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Functionality:
When this repo receives a webhook with a package name and repo name:

1. Get the latest tag at the repo
2. Check tag against current version in `requirements.txt`
3. Update requirements.txt
4. Commit, Push, Tag, Push

## Notes:

- This action uses a repo access token for git instead of `secrets.GITHUB_TOKEN`. A push made using GITHUB_TOKEN will not trigger other actions whereas using another private access token will.