### PR TITLE
deploy: Ignore venv directory

### DIFF
--- a/pyfrc/mains/cli_deploy.py
+++ b/pyfrc/mains/cli_deploy.py
@@ -436,7 +436,7 @@ class PyFrcDeploy:
 
             # skip .svn, .git, .hg, etc directories
             for d in dirs[:]:
-                if d.startswith(".") or d == "__pycache__":
+                if d.startswith(".") or d in ("__pycache__", "venv"):
                     dirs.remove(d)
 
             # skip .pyc files


### PR DESCRIPTION
PyCharm creates a virtualenv in a `venv` subdirectory by default.