### PR TITLE
Fix for #194: Create pre-deploy hooks?

### DIFF
--- a/pyfrc/mains/cli_deploy.py
+++ b/pyfrc/mains/cli_deploy.py
@@ -1,6 +1,7 @@
 import argparse
 import contextlib
 import inspect
+import pathlib
 import os
 import sys
 import re
@@ -175,6 +176,13 @@ class PyFrcDeploy:
                 "If you really want to do this, then specify the --nonstandard argument"
             )
             return 1
+
+        if (pathlib.Path(robot_path) / "hooks.py").exists():
+            """
+            Code to do things like, run the hooks should go here?
+            """
+        else:
+            logging.info("Not enabling custom deploy hooks, hooks.py not found")
 
         if not options.large and not self._check_large_files(robot_path):
             return 1


### PR DESCRIPTION
This is supposed to be a fix for #194, my idea is to implement a hooks.py that can be optionally included.

I dont like it quite as much as the always present .json idea @virtuald had because that would do all this automatically but perhaps its the better option. So id like to explore that too.