### PR TITLE
deploy: Fix ignore file extensions

### DIFF
--- a/pyfrc/mains/cli_deploy.py
+++ b/pyfrc/mains/cli_deploy.py
@@ -7,8 +7,6 @@ import inspect
 import json
 import os
 import sys
-import re
-
 import shutil
 import tempfile
 import threading
@@ -512,7 +510,7 @@ class PyFrcDeploy:
     def _copy_to_tmpdir(self, tmp_dir, robot_path, dry_run=False):
 
         upload_files = []
-        ignore_exts = frozenset({"pyc", "whl", "ipk", "zip", "gz", "wpilog"})
+        ignore_exts = frozenset({".pyc", ".whl", ".ipk", ".zip", ".gz", ".wpilog"})
 
         for root, dirs, files in os.walk(robot_path):
             prefix = root[len(robot_path) + 1 :]


### PR DESCRIPTION
The `ext` that [`os.path.splitext`] returns is documented to include the leading `.` if there is an extension.

[`os.path.splitext`]: https://docs.python.org/3/library/os.path.html#os.path.splitext