### PR TITLE
Update cli_deploy.py

### DIFF
--- a/pyfrc/mains/cli_deploy.py
+++ b/pyfrc/mains/cli_deploy.py
@@ -10,6 +10,7 @@ import sys
 import shutil
 import tempfile
 import threading
+import getpass
 
 from os.path import abspath, basename, dirname, join, splitext
 from pathlib import PurePosixPath
@@ -211,7 +212,7 @@ class PyFrcDeploy:
 
         deploy_data = {
             "deploy-host": socket.gethostname(),  # os.uname doesn't work on systems that use non-unix os
-            "deploy-user": os.getlogin(),
+            "deploy-user": getpass.getuser(),
             "deploy-date": datetime.datetime.now().replace(microsecond=0).isoformat(),
             "code-path": robot_path,
         }


### PR DESCRIPTION
Using os.getlogin() doesn't work with VS Code terminals since they are non controlling terminal (child of a process). Using getpass.getuser() uses environment variables and works with both controlling and non controlling terminals.