### PR TITLE
Use pytest-xdist to isolate tests

### DIFF
--- a/pyfrc/mains/cli_add_tests.py
+++ b/pyfrc/mains/cli_add_tests.py
@@ -10,6 +10,30 @@ builtin_tests = """'''
 from pyfrc.tests import *
 """
 
+conftest = """'''
+    This file registesr the PyFrcPlugin so it can be found during
+    distributed tests with pytest-xdist
+'''
+
+import sys
+import pathlib
+from pyfrc.test_support.pytest_plugin import PyFrcPlugin
+
+# Add the location of robot.py to our path
+parentdir = pathlib.Path(__file__).parent.parent
+sys.path.append(str(parentdir))
+import robot
+
+def pytest_configure(config):
+    if config.pluginmanager.has_plugin("pyfrc_plugin"):
+        # Avoid double registration
+        return
+    robot_class = robot.MyRobot
+    robot_file = parentdir/'robot.py'
+    plugin = PyFrcPlugin(robot_class, robot_file)
+    config.pluginmanager.register(plugin, "pyfrc_plugin")
+"""
+
 
 class PyFrcAddTests:
     """
@@ -48,5 +72,13 @@ class PyFrcAddTests:
                 fp.write(builtin_tests)
             print("- builtin tests created at", builtin_tests_file)
 
+        conftest_file = test_directory / "conftest.py"
+        if conftest_file.exists():
+            print("- conftest.py already exists")
+        else:
+            with open(conftest_file, "w") as fp:
+                fp.write(conftest)
+            print("- conftest created at", conftest_file)
+
         print()
-        print("Robot tests can be ran via 'python3 -m robotpy test'")
+        print("Robot tests can be ran via 'robotpy test'")

--- a/pyfrc/mains/cli_add_tests.py
+++ b/pyfrc/mains/cli_add_tests.py
@@ -10,30 +10,6 @@ builtin_tests = """'''
 from pyfrc.tests import *
 """
 
-conftest = """'''
-    This file registesr the PyFrcPlugin so it can be found during
-    distributed tests with pytest-xdist
-'''
-
-import sys
-import pathlib
-from pyfrc.test_support.pytest_plugin import PyFrcPlugin
-
-# Add the location of robot.py to our path
-parentdir = pathlib.Path(__file__).parent.parent
-sys.path.append(str(parentdir))
-import robot
-
-def pytest_configure(config):
-    if config.pluginmanager.has_plugin("pyfrc_plugin"):
-        # Avoid double registration
-        return
-    robot_class = robot.MyRobot
-    robot_file = parentdir/'robot.py'
-    plugin = PyFrcPlugin(robot_class, robot_file)
-    config.pluginmanager.register(plugin, "pyfrc_plugin")
-"""
-
 
 class PyFrcAddTests:
     """
@@ -72,13 +48,4 @@ class PyFrcAddTests:
                 fp.write(builtin_tests)
             print("- builtin tests created at", builtin_tests_file)
 
-        conftest_file = test_directory / "conftest.py"
-        if conftest_file.exists():
-            print("- conftest.py already exists")
-        else:
-            with open(conftest_file, "w") as fp:
-                fp.write(conftest)
-            print("- conftest created at", conftest_file)
-
-        print()
         print("Robot tests can be ran via 'robotpy test'")

--- a/pyfrc/mains/cli_test.py
+++ b/pyfrc/mains/cli_test.py
@@ -19,6 +19,24 @@ from ..test_support import pytest_plugin
 # could be a useful thing. Will have to consider that later.
 
 
+import sys
+import pathlib
+from pyfrc.test_support.pytest_plugin import PyFrcPlugin
+# Tests are always run from the top directory of the robot project
+# so the location of robot.py should be the current working directory
+sys.path.append('.')
+import robot
+
+def pytest_configure(config):
+    if config.pluginmanager.has_plugin("pyfrc_plugin"):
+        # Avoid double registration
+        return
+    robot_class = robot.MyRobot
+    robot_file = './robot.py'
+    plugin = PyFrcPlugin(robot_class, robot_file)
+    config.pluginmanager.register(plugin, "pyfrc_plugin")
+
+
 class _TryAgain(Exception):
     pass
 

--- a/pyfrc/test_support/pytest_plugin.py
+++ b/pyfrc/test_support/pytest_plugin.py
@@ -38,6 +38,8 @@ class PyFrcPlugin:
             robot_file.parent,
         )
 
+        print('robot file: ', robot_file)
+
         # Tests need to know when robotInit is called, so override the robot
         # to do that
         class TestRobot(robot_class):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ packages = find:
 install_requires =
     pytest>=3.9
     pytest-reraise
+    pytest-xdist>=3.6.1
     pint>=0.11.0
 
     wpilib>=2025.0.0b1,<2026


### PR DESCRIPTION
This was built from the 2024.0.1 tag as I had robot code compliant with that exhibiting problems during tests due to CANId reuse between them and vendor code not releasing them.