### PR TITLE
Only isolate tests that use the robot fixture

### DIFF
--- a/pyfrc/test_support/pytest_dist_plugin.py
+++ b/pyfrc/test_support/pytest_dist_plugin.py
@@ -158,7 +158,10 @@ class DistPlugin:
         multiprocessing.set_start_method("spawn")
 
         for item in items:
-            # Overwrite the runtest protocol for each item
+            if "robot" not in item.fixturenames:
+                continue
+
+            # Overwrite the runtest protocol for each item that needs the robot
             item.runtest = _make_runtest(
                 item,
                 config,
@@ -172,7 +175,7 @@ class DistPlugin:
     # These fixtures match the ones in PyFrcPlugin but these have no effect
     #
 
-    @pytest.fixture(scope="function", autouse=True)
+    @pytest.fixture(scope="function")
     def robot(self):
         pass
 

--- a/pyfrc/test_support/pytest_plugin.py
+++ b/pyfrc/test_support/pytest_plugin.py
@@ -73,7 +73,7 @@ class PyFrcPlugin:
     # corresponding function will be passed to your test as that argument.
     #
 
-    @pytest.fixture(scope="function", autouse=True)
+    @pytest.fixture(scope="function")
     def robot(self):
         """
         Your robot instance


### PR DESCRIPTION
- No longer mark robot fixture as autouse
- Fixes #240