### PR TITLE
The IsolatedTestsPlugin respects pytest order markers.

### DIFF
--- a/pyfrc/test_support/pytest_isolated_tests_plugin.py
+++ b/pyfrc/test_support/pytest_isolated_tests_plugin.py
@@ -245,6 +245,12 @@ class IsolatedTestsPlugin:
                     deferred.append(item)
                     continue
 
+                # If this test has an order marker, drain all running subprocesses first
+                # so that ordered tests execute sequentially and never in parallel.
+                if item.get_closest_marker("order") is not None:
+                    while running:
+                        self._wait_for_jobs(running, session)
+
                 while len(running) >= self._parallelism:
                     self._wait_for_jobs(running, session)
 

--- a/pyfrc/test_support/pytest_isolated_tests_plugin.py
+++ b/pyfrc/test_support/pytest_isolated_tests_plugin.py
@@ -247,6 +247,13 @@ class IsolatedTestsPlugin:
 
                 # If this test has an order marker, drain all running subprocesses first
                 # so that ordered tests execute sequentially and never in parallel.
+                # This works because the pytest-order plugin presorts the list of test
+                # before they reach this point in the code.
+                #
+                # The above code which defers code without a robot fixture will break
+                # @pytest.maker.order for order configurations which involve both robot
+                # fixture tests and non robot fixture tests.
+
                 if item.get_closest_marker("order") is not None:
                     while running:
                         self._wait_for_jobs(running, session)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-order

--- a/tests/test_pytest_plugins.py
+++ b/tests/test_pytest_plugins.py
@@ -419,3 +419,72 @@ def test_state_transitions(robot, control):
     )
 
     result.assert_outcomes(passed=1)
+
+
+def test_isolated_plugin_order_marker_enforces_sequencing(pytester):
+    """
+    Robot-fixture tests with @pytest.mark.order run sequentially even when
+    parallelism would otherwise allow them to overlap.  Step 1 writes a
+    sentinel file; step 2 asserts it exists.  Without the barrier the two
+    subprocesses would race and step 2 would likely fail.
+    """
+    _make_robot_module(pytester)
+    _configure_isolated_plugin(pytester, parallelism=4)  # high limit rules out throttling
+    pytester.makepyfile(test_order_marker_sequencing="""
+import pathlib
+import pytest
+
+
+@pytest.mark.order(1)
+def test_step1_writes_sentinel(robot):
+    pathlib.Path("order_marker_sequencing_sentinel.txt").write_text("done")
+
+
+@pytest.mark.order(2)
+def test_step2_reads_sentinel(robot):
+    assert pathlib.Path("order_marker_sequencing_sentinel.txt").exists(), (
+        "order_marker_sequencing_sentinel.txt must be written by step1 before step2 starts"
+    )
+""")
+
+    result = pytester.runpytest_subprocess("-vv")
+    result.assert_outcomes(passed=2)
+
+
+def test_isolated_plugin_unordered_robot_tests_still_run_in_parallel(pytester):
+    """
+    Robot-fixture tests WITHOUT @pytest.mark.order must not be serialised by the
+    fix.  With parallelism=2, two unordered tests sleep long enough that they
+    must overlap in wall-clock time if they run in parallel.
+    """
+    _make_robot_module(pytester)
+    _configure_isolated_plugin(pytester, parallelism=2)
+    pytester.makepyfile(test_unordered_parallel_execution="""
+import pathlib
+import time
+
+
+def test_robot_a(robot):
+    pathlib.Path("unordered_parallel_a_start.txt").write_text(str(time.monotonic()))
+    time.sleep(1.5)
+    pathlib.Path("unordered_parallel_a_end.txt").write_text(str(time.monotonic()))
+
+
+def test_robot_b(robot):
+    pathlib.Path("unordered_parallel_b_start.txt").write_text(str(time.monotonic()))
+    time.sleep(1.5)
+    pathlib.Path("unordered_parallel_b_end.txt").write_text(str(time.monotonic()))
+""")
+
+    result = pytester.runpytest_subprocess("-vv")
+    result.assert_outcomes(passed=2)
+
+    root = pathlib.Path(pytester.path)
+    a_start = float((root / "unordered_parallel_a_start.txt").read_text())
+    a_end = float((root / "unordered_parallel_a_end.txt").read_text())
+    b_start = float((root / "unordered_parallel_b_start.txt").read_text())
+
+    # Parallel execution: B started before A finished
+    assert b_start < a_end, (
+        f"Expected parallel execution: b_start={b_start:.3f} a_end={a_end:.3f}"
+    )

--- a/tests/test_pytest_plugins.py
+++ b/tests/test_pytest_plugins.py
@@ -421,25 +421,21 @@ def test_state_transitions(robot, control):
     result.assert_outcomes(passed=1)
 
 
-def test_isolated_plugin_order_marker_enforces_sequencing(pytester):
+def test_robot_isolated_plugin_order_marker_enforces_numeric_sequencing(pytester):
     """
-    Robot-fixture tests with @pytest.mark.order run sequentially even when
-    parallelism would otherwise allow them to overlap.  Step 1 writes a
-    sentinel file; step 2 asserts it exists.  Without the barrier the two
-    subprocesses would race and step 2 would likely fail.
+    Robot-fixture tests with @pytest.mark.order run sequentially with
+    even @pytest.mark.order(NUMERICAL_ORDER) when parallelism would
+    otherwise allow them to overlap.  Step 1 writes a sentinel file;
+    step 2 asserts it exists.  Without the barrier the two subprocesses
+    would race and step 2 would likely fail.
     """
     _make_robot_module(pytester)
     _configure_isolated_plugin(
         pytester, parallelism=4
     )  # high limit rules out throttling
-    pytester.makepyfile(test_order_marker_sequencing="""
+    pytester.makepyfile(test_robot_order_marker_sequencing="""
 import pathlib
 import pytest
-
-
-@pytest.mark.order(1)
-def test_step1_writes_sentinel(robot):
-    pathlib.Path("order_marker_sequencing_sentinel.txt").write_text("done")
 
 
 @pytest.mark.order(2)
@@ -447,6 +443,73 @@ def test_step2_reads_sentinel(robot):
     assert pathlib.Path("order_marker_sequencing_sentinel.txt").exists(), (
         "order_marker_sequencing_sentinel.txt must be written by step1 before step2 starts"
     )
+
+
+@pytest.mark.order(1)
+def test_step1_writes_sentinel(robot):
+    pathlib.Path("order_marker_sequencing_sentinel.txt").write_text("done")
+""")
+
+    result = pytester.runpytest_subprocess("-vv")
+    result.assert_outcomes(passed=2)
+
+
+def test_robot_isolated_plugin_order_marker_enforces_after_sequencing(pytester):
+    """
+    Robot-fixture tests with @pytest.mark.order run sequentially using
+    pytest.mark.order(after="TEST_NAME") even when parallelism would
+    otherwise allow them to overlap.  Step 1 writes a sentinel file;
+    step 2 asserts it exists.  Without the barrier the two subprocesses
+    would race and step 2 would likely fail.
+    """
+    _make_robot_module(pytester)
+    _configure_isolated_plugin(
+        pytester, parallelism=4
+    )  # high limit rules out throttling
+    pytester.makepyfile(test_robot_order_marker_after_sequencing="""
+import pathlib
+import pytest
+
+
+@pytest.mark.order(after="test_step1_writes_sentinel")
+def test_step2_reads_sentinel(robot):
+    assert pathlib.Path("order_marker_sequencing_after_sentinel.txt").exists(), (
+        "order_marker_sequencing_sentinel.txt must be written by step1 before step2 starts"
+    )
+
+
+def test_step1_writes_sentinel(robot):
+    pathlib.Path("order_marker_sequencing_after_sentinel.txt").write_text("done")
+""")
+
+    result = pytester.runpytest_subprocess("-vv")
+    result.assert_outcomes(passed=2)
+
+
+def test_nonrobot_isolated_plugin_order_marker_enforces_sequencing(pytester):
+    """
+    Non-robot tests with @pytest.mark.order run in the declared order.
+    Step 1 writes a sentinel file; step 2 asserts it exists.  Without
+    correct ordering, step 2 would run before step 1 and fail.
+    """
+    _make_robot_module(pytester)
+    _configure_isolated_plugin(
+        pytester, parallelism=4
+    )  # high limit rules out throttling
+    pytester.makepyfile(test_nonrobot_order_marker_after_sequencing="""
+import pathlib
+import pytest
+
+
+@pytest.mark.order(after="test_step1_writes_sentinel")
+def test_step2_reads_sentinel():
+    assert pathlib.Path("order_marker_sequencing_nonrobot_sentinel.txt").exists(), (
+        "order_marker_sequencing_sentinel.txt must be written by step1 before step2 starts"
+    )
+
+
+def test_step1_writes_sentinel():
+    pathlib.Path("order_marker_sequencing_nonrobot_sentinel.txt").write_text("done")
 """)
 
     result = pytester.runpytest_subprocess("-vv")
@@ -461,18 +524,56 @@ def test_isolated_plugin_unordered_robot_tests_still_run_in_parallel(pytester):
     """
     _make_robot_module(pytester)
     _configure_isolated_plugin(pytester, parallelism=2)
-    pytester.makepyfile(test_unordered_parallel_execution="""
+    pytester.makepyfile(test_unordered_robot_parallel_execution="""
 import pathlib
 import time
 
 
 def test_robot_a(robot):
+    pathlib.Path("unordered_robot_parallel_a_start.txt").write_text(str(time.monotonic()))
+    time.sleep(1.5)
+    pathlib.Path("unordered_robot_parallel_a_end.txt").write_text(str(time.monotonic()))
+
+
+def test_robot_b(robot):
+    pathlib.Path("unordered_robot_parallel_b_start.txt").write_text(str(time.monotonic()))
+    time.sleep(1.5)
+    pathlib.Path("unordered_robot_parallel_b_end.txt").write_text(str(time.monotonic()))
+""")
+
+    result = pytester.runpytest_subprocess("-vv")
+    result.assert_outcomes(passed=2)
+
+    root = pathlib.Path(pytester.path)
+    a_start = float((root / "unordered_robot_parallel_a_start.txt").read_text())
+    a_end = float((root / "unordered_robot_parallel_a_end.txt").read_text())
+    b_start = float((root / "unordered_robot_parallel_b_start.txt").read_text())
+
+    # Parallel execution: B started before A finished
+    assert (
+        b_start < a_end
+    ), f"Expected parallel execution: b_start={b_start:.3f} a_end={a_end:.3f}"
+
+def test_isolated_plugin_unordered_non_robot_tests_still_run_in_parallel(pytester):
+    """
+    non-robot tests WITHOUT @pytest.mark.order must not be serialised by the
+    fix.  With parallelism=2, two unordered tests sleep long enough that they
+    must overlap in wall-clock time if they run in parallel.
+    """
+    _make_robot_module(pytester)
+    _configure_isolated_plugin(pytester, parallelism=2)
+    pytester.makepyfile(test_unordered_parallel_execution="""
+import pathlib
+import time
+
+
+def test_a():
     pathlib.Path("unordered_parallel_a_start.txt").write_text(str(time.monotonic()))
     time.sleep(1.5)
     pathlib.Path("unordered_parallel_a_end.txt").write_text(str(time.monotonic()))
 
 
-def test_robot_b(robot):
+def test_b(robot):
     pathlib.Path("unordered_parallel_b_start.txt").write_text(str(time.monotonic()))
     time.sleep(1.5)
     pathlib.Path("unordered_parallel_b_end.txt").write_text(str(time.monotonic()))

--- a/tests/test_pytest_plugins.py
+++ b/tests/test_pytest_plugins.py
@@ -429,7 +429,9 @@ def test_isolated_plugin_order_marker_enforces_sequencing(pytester):
     subprocesses would race and step 2 would likely fail.
     """
     _make_robot_module(pytester)
-    _configure_isolated_plugin(pytester, parallelism=4)  # high limit rules out throttling
+    _configure_isolated_plugin(
+        pytester, parallelism=4
+    )  # high limit rules out throttling
     pytester.makepyfile(test_order_marker_sequencing="""
 import pathlib
 import pytest
@@ -485,6 +487,6 @@ def test_robot_b(robot):
     b_start = float((root / "unordered_parallel_b_start.txt").read_text())
 
     # Parallel execution: B started before A finished
-    assert b_start < a_end, (
-        f"Expected parallel execution: b_start={b_start:.3f} a_end={a_end:.3f}"
-    )
+    assert (
+        b_start < a_end
+    ), f"Expected parallel execution: b_start={b_start:.3f} a_end={a_end:.3f}"

--- a/tests/test_pytest_plugins.py
+++ b/tests/test_pytest_plugins.py
@@ -554,6 +554,7 @@ def test_robot_b(robot):
         b_start < a_end
     ), f"Expected parallel execution: b_start={b_start:.3f} a_end={a_end:.3f}"
 
+
 def test_isolated_plugin_unordered_non_robot_tests_still_run_in_parallel(pytester):
     """
     non-robot tests WITHOUT @pytest.mark.order must not be serialised by the


### PR DESCRIPTION
When using robotpy test to test a simulated pykit robot and following pykit replay of the robot, it is uselful to run robot tests ordered so that the replay uses the controlled previous run.

This change makes the IsolatedTestsPlugin respect pytest order markers.

-Thanks
-Mike

An example test file that uses the order markers:

```
"""
Test that the robot can pyKit sim and replay the sim
"""

import math
import os
import shutil
from typing import Tuple

import pytest
import wpilib
from wpiutil.log import DataLogReader
from constants import LoggerState
from pykit.wpilog.wpilogwriter import WPILOGWriter
from tests.controllerTestPyKitReplay import PyKitReplayTestController


# Keys whose values legitimately differ between real and replay
_SKIP_PREFIXES = (
    "Logger/",
    "LoggedRobot/",
    "SystemStats/",
    "Console",
    "LogTracer/",
)

# Keys containing these substrings are skipped regardless of prefix.
# /sol/ — logged by WrapperedPoseEstPhotonCamera which runs only in sim, not replay.
_SKIP_SUBSTRINGS = ("/sol/",)

step2InputLogName = "test_log_and_replay_step2.wpilog"
globalStep2Path = os.path.join(WPILOGWriter.defaultPathSim, step2InputLogName)
replayLogPath = os.path.join(
    WPILOGWriter.defaultPathSim, "test_log_and_replay_step2_sim.wpilog"
)


@pytest.fixture()
def forceRobotInReplay():
    LoggerState().logPath = globalStep2Path
    print("-----------------------")
    print("-----------------------")
    print(f"-----------------------Forcing replay mode LOG_PATH: {globalStep2Path}\n\n")
    print("-----------------------")
    print("-----------------------")


@pytest.fixture(scope="function")
def pykitReplayControl(reraise, robot: wpilib.RobotBase) -> PyKitReplayTestController:
    """
    A pytest fixture that provides control over your robot
    """
    return PyKitReplayTestController(reraise, robot)


@pytest.mark.order(1)
def test_log_and_replay_step1(pykitReplayControl, robot):
    # -----------------------------------------------------------------------
    # Phase 1: sim run
    # -----------------------------------------------------------------------
    # Set c_backup as the active auto so the chooser logs it and replay can replay it.
    # RobotContainer adds non-side autos with a "C-" prefix ("C-c_backup").
    robot.container.autoChooser.sendableChooser.setDefaultOption(
        "C-c_backup", "C-c_backup"
    )

    with pykitReplayControl.run_robot():
        pykitReplayControl.step_timing(seconds=0.5, autonomous=True, enabled=False)
        pykitReplayControl.step_timing(seconds=15.0, autonomous=True, enabled=True)
        pykitReplayControl.step_timing(seconds=0.5, autonomous=True, enabled=False)

    step1LogPath = robot.loggerSetup.logFiles[0]

    step1Dir = os.path.dirname(step1LogPath)
    step2Path = os.path.join(step1Dir, step2InputLogName)
    shutil.copyfile(step1LogPath, step2Path)

    assert os.path.exists(step2Path), f"Log file not created: {step2Path}"


@pytest.mark.order(2)
def test_log_and_replay_step2(forceRobotInReplay, pykitReplayControl, robot):
    # -----------------------------------------------------------------------
    # Phase 2: replay the pykit log
    # -----------------------------------------------------------------------

    with pykitReplayControl.run_robot():
        pykitReplayControl.step_timing(
            seconds=0.5, autonomous=True, enabled=False, assert_alive=False
        )
        pykitReplayControl.step_timing(
            seconds=15.0, autonomous=True, enabled=True, assert_alive=False
        )
        pykitReplayControl.step_timing(
            seconds=0.5, autonomous=True, enabled=False, assert_alive=False
        )

    assert os.path.exists(replayLogPath), f"Replay log not created: {replayLogPath}"

    # -----------------------------------------------------------------------
    # Compare logs
    # -----------------------------------------------------------------------
    _compareLogFiles(globalStep2Path, replayLogPath)


# ---------------------------------------------------------------------------
# Log comparison helpers
# ---------------------------------------------------------------------------


def _readLogEntries(
    path: str, prefix: str
) -> Tuple[dict[str, list], dict[str, list[int]]]:
    """Read all entries under `prefix`, return {bare_key: [val, ...]}."""
    reader = DataLogReader(path)
    entryNames: dict[int, str] = {}
    result: dict[str, list] = {}
    times_us: dict[str, list[int]] = {}

    for record in reader:
        if record.isControl():
            if record.isStart():
                sd = record.getStartData()
                if sd.name.startswith(prefix):
                    entryNames[sd.entry] = sd.name[len(prefix) :]
        else:
            name = entryNames.get(record.getEntry())
            if name is None:
                continue
            if any(name.startswith(skip) for skip in _SKIP_PREFIXES):
                continue
            if any(sub in name for sub in _SKIP_SUBSTRINGS):
                continue
            result.setdefault(name, [])
            times_us.setdefault(name, [])
            for getter in (
                record.getDouble,
                record.getFloat,
                record.getInteger,
                record.getBoolean,
                record.getString,
                record.getDoubleArray,
            ):
                try:
                    result[name].append(getter())
                    times_us[name].append(record.getTimestamp())
                    break
                except Exception:
                    continue

    return (result, times_us)


def _compareLogFiles(origPath: str, replayPath: str, tol: float = 1e-2) -> None:
    realOut, realTimesDict = _readLogEntries(origPath, "/RealOutputs/")
    replayOut, replayTimesDict = _readLogEntries(replayPath, "/ReplayOutputs/")

    missingKeys = set(realOut) - set(replayOut)
    assert not missingKeys, (
        f"Keys in RealOutputs missing from ReplayOutputs: {missingKeys}"
    )

    countMismatch = False
    for key, realVals in realOut.items():
        replayVals = replayOut[key]
        realTimes_us = realTimesDict[key]
        replayTimes_us = replayTimesDict[key]
        for i, (rv, pv, rTime_us, pTime_us) in enumerate(
            zip(realVals, replayVals, realTimes_us, replayTimes_us)
        ):
            # TODO we need a better way to control absolute and relative tolerance by type of value.
            if isinstance(rv, float):
                assert math.isclose(rv, pv, rel_tol=tol, abs_tol=tol), (
                    f"{key}[{i}]: real={rv} at {rTime_us}, replay={pv} at {pTime_us}"
                )
            elif isinstance(rv, list):
                for j, (re, pe) in enumerate(zip(rv, pv)):
                    if isinstance(re, float):
                        assert math.isclose(re, pe, rel_tol=tol, abs_tol=tol), (
                            f"{key}[{i}][{j}]: real={re} at {rTime_us}, replay={pe} at {pTime_us}"
                        )
            else:
                assert rv == pv, (
                    f"{key}[{i}]: real={rv} at {rTime_us}, replay={pv} at {pTime_us}"
                )
            assert rTime_us == pTime_us, f"{key}[{i}]: at {rTime_us}, at {pTime_us}"
        lenRealVals = len(realVals)
        lenReplayVals = len(replayVals)
        if lenRealVals != lenReplayVals:
            countMismatch = True
            print(f"Cycle count mismatch for {key}: {lenRealVals} vs {lenReplayVals}")
    assert not countMismatch, "A count mismatch occurred."

```