### PR TITLE
Isolated tests execute in marker order

### DIFF
--- a/pyfrc/test_support/pytest_isolated_tests_plugin.py
+++ b/pyfrc/test_support/pytest_isolated_tests_plugin.py
@@ -262,7 +262,10 @@ class IsolatedTestsPlugin:
                 # so that ordered tests execute sequentially and never in parallel.
                 # This works because the pytest-order plugin presorts the list of test
                 # before they reach this point in the code.
-
+                # This handles the @pytest.mark.order(<ORDINAL>) and @pytest.mark.order(after="TEST_NAME")
+                # cases.
+                ordermarker = item.get_closest_marker("order")
+                ordermarker
                 if item.get_closest_marker("order") is not None:
                     while running:
                         self._wait_for_jobs(running, session)
@@ -274,6 +277,17 @@ class IsolatedTestsPlugin:
 
                     running.append(self._start_isolated_test(item))
                     self._maybe_raise(session)
+
+                    # If this test has an order marker, drain all running subprocesses after
+                    # so that ordered tests execute sequentially and never in parallel.
+                    # This works because the pytest-order plugin presorts the list of test
+                    # before they reach this point in the code.
+                    # This handles the @pytest.mark.order(before="TEST_NAME")
+                    # cases.
+                    if item.get_closest_marker("order") is not None:
+                        while running:
+                            self._wait_for_jobs(running, session)
+
                 else:
                     # This test runs in this process.
 
@@ -283,14 +297,14 @@ class IsolatedTestsPlugin:
                     nextitem = (
                         session.items[idx + 1] if idx + 1 < len(session.items) else None
                     )
-                    nextitem = (
+                    nextitemForRunTest = (
                         None
                         if nextitem is None or "robot" in nextitem.fixturenames
                         else nextitem
                     )
 
                     session.config.hook.pytest_runtest_protocol(
-                        item=item, nextitem=nextitem
+                        item=item, nextitem=nextitemForRunTest
                     )
                     self._maybe_raise(session)
 

--- a/pyfrc/test_support/pytest_isolated_tests_plugin.py
+++ b/pyfrc/test_support/pytest_isolated_tests_plugin.py
@@ -147,7 +147,23 @@ def _run_test(
     worker_plugin = WorkerPlugin(pipe)
 
     ec = pytest.main(
-        [item_nodeid, "--no-header", "-p", "no:terminalreporter", *config_args],
+        # "-p", "no:order" tells pytest in the isolated subprocess to not run pytest-order or look at the
+        # @pytest.marder.order decorators. This is fine because the isolated subprocess runs just
+        # one test at a time, so order does not matter at this level. The purpose of not running
+        # pytest-order is so that it doesn't give misleading warnings like:
+        # WARNING: cannot execute 'test_step2_reads_sentinel' relative to others: 'test_step1_writes_sentinel' - ignoring the marker.
+        # The warning is accurate from the subprocess point of view, it can't see the other test.
+        # But the warning is misleading because the main process sucessefully ordered the tests.
+        # Passing "-p", "no:order". Causes the misleading warnings to stop.
+        [
+            item_nodeid,
+            "--no-header",
+            "-p",
+            "no:terminalreporter",
+            "-p",
+            "no:order",
+            *config_args,
+        ],
         plugins=[plugin, worker_plugin],
     )
 
@@ -235,29 +251,48 @@ class IsolatedTestsPlugin:
             return True
 
         running: list[IsolatedTestJob] = []
-        deferred: list[pytest.Function] = []
         try:
-            # Start any tests that use the robot fixture first. Tests that don't
-            # use the robot fixture will be ran later
-            for item in session.items:
+            # Start tests in the order that they are given to us,
+            # running robot fixture tests in sub process, preserving
+            # order marker boundaries.
+            for idx, item in enumerate(session.items):
                 assert isinstance(item, pytest.Function)
-                if "robot" not in item.fixturenames:
-                    deferred.append(item)
-                    continue
 
-                while len(running) >= self._parallelism:
-                    self._wait_for_jobs(running, session)
+                # If this test has an order marker, drain all running subprocesses first
+                # so that ordered tests execute sequentially and never in parallel.
+                # This works because the pytest-order plugin presorts the list of test
+                # before they reach this point in the code.
 
-                running.append(self._start_isolated_test(item))
-                self._maybe_raise(session)
+                if item.get_closest_marker("order") is not None:
+                    while running:
+                        self._wait_for_jobs(running, session)
 
-            # Run the in-process tests now while the robot tests are finishing
-            for idx, item in enumerate(deferred):
-                nextitem = deferred[idx + 1] if idx + 1 < len(deferred) else None
-                session.config.hook.pytest_runtest_protocol(
-                    item=item, nextitem=nextitem
-                )
-                self._maybe_raise(session)
+                if "robot" in item.fixturenames:
+                    # This test uses a "robot" fixture, run it in an isolated subprocess.
+                    while len(running) >= self._parallelism:
+                        self._wait_for_jobs(running, session)
+
+                    running.append(self._start_isolated_test(item))
+                    self._maybe_raise(session)
+                else:
+                    # This test runs in this process.
+
+                    # Determine if the next item to run is also "in process" to pass it as a
+                    # hint to pytest_runtest_protocol so that it can optimize teardown in preparation
+                    # for the the nextitem to be tested after this item.
+                    nextitem = (
+                        session.items[idx + 1] if idx + 1 < len(session.items) else None
+                    )
+                    nextitem = (
+                        None
+                        if nextitem is None or "robot" in nextitem.fixturenames
+                        else nextitem
+                    )
+
+                    session.config.hook.pytest_runtest_protocol(
+                        item=item, nextitem=nextitem
+                    )
+                    self._maybe_raise(session)
 
             while running:
                 self._wait_for_jobs(running, session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 dependencies = [
   "pytest>=3.9",
+  "pytest-order",
   "pytest-reraise",
   "pint>=0.24.4",
   "wpilib>=2026.1.1b1,<2027",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-order

--- a/tests/test_pytest_plugins.py
+++ b/tests/test_pytest_plugins.py
@@ -421,10 +421,14 @@ def test_state_transitions(robot, control):
     result.assert_outcomes(passed=1)
 
 
-@pytest.mark.parametrize("marker_style", ["numeric", "after"])
+@pytest.mark.parametrize("marker_style", ["numeric", "after", "before"])
 @pytest.mark.parametrize(
     "first_type, middle_type, last_type",
     [
+        ("ROBOT", "ROBOT", None),
+        ("ROBOT", "PLAIN", None),
+        ("PLAIN", "ROBOT", None),
+        ("PLAIN", "PLAIN", None),
         ("ROBOT", "ROBOT", "PLAIN"),
         ("ROBOT", "PLAIN", "ROBOT"),
         ("PLAIN", "ROBOT", "ROBOT"),
@@ -460,31 +464,47 @@ def test_order_marker_enforces_sequencing(
         first_mark = "@pytest.mark.order(1)\n"
         middle_mark = "@pytest.mark.order(2)\n"
         last_mark = "@pytest.mark.order(3)\n"
+    elif marker_style == "before":
+        first_mark = '@pytest.mark.order(before="test_middle")\n'
+        middle_mark = '@pytest.mark.order(before="test_last")\n'
+        last_mark = ""
     else:
         first_mark = ""
         middle_mark = '@pytest.mark.order(after="test_first")\n'
         last_mark = '@pytest.mark.order(after="test_middle")\n'
 
-    pytester.makepyfile(test_order_sequence=f"""\
+    pytester.makepyfile(
+        test_order_sequence=(
+            f"""\
 import pathlib
 import pytest
 
 
-{last_mark}def test_last{params(last_type)}:
+"""
+            + (
+                f"""{last_mark}def test_last{params(last_type)}:
     assert pathlib.Path("sentinel_2.txt").exists(), "test_middle must run before test_last"
 
 
-{middle_mark}def test_middle{params(middle_type)}:
+"""
+                if last_type is not None
+                else ""
+            )
+            + f"""{middle_mark}def test_middle{params(middle_type)}:
     assert pathlib.Path("sentinel_1.txt").exists(), "test_first must run before test_middle"
     pathlib.Path("sentinel_2.txt").write_text("done")
 
 
 {first_mark}def test_first{params(first_type)}:
     pathlib.Path("sentinel_1.txt").write_text("done")
-""")
+"""
+        )
+    )
 
     result = pytester.runpytest_subprocess("-vv")
-    result.assert_outcomes(passed=3)
+    list_of_tests = [first_type, middle_type, last_type]
+    count_of_tests = sum(x is not None for x in list_of_tests)
+    result.assert_outcomes(passed=count_of_tests)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pytest_plugins.py
+++ b/tests/test_pytest_plugins.py
@@ -419,3 +419,118 @@ def test_state_transitions(robot, control):
     )
 
     result.assert_outcomes(passed=1)
+
+
+@pytest.mark.parametrize("marker_style", ["numeric", "after"])
+@pytest.mark.parametrize(
+    "first_type, middle_type, last_type",
+    [
+        ("ROBOT", "ROBOT", "PLAIN"),
+        ("ROBOT", "PLAIN", "ROBOT"),
+        ("PLAIN", "ROBOT", "ROBOT"),
+        ("ROBOT", "PLAIN", "PLAIN"),
+        ("PLAIN", "ROBOT", "PLAIN"),
+        ("PLAIN", "PLAIN", "ROBOT"),
+    ],
+)
+def test_order_marker_enforces_sequencing(
+    pytester, first_type, middle_type, last_type, marker_style
+):
+    """
+    Order markers enforce a first→middle→last chain across all mixed
+    robot/non-robot permutations.
+
+    test_first writes sentinel_1; test_middle reads sentinel_1 and writes
+    sentinel_2; test_last reads sentinel_2.  The file lists them in reverse
+    (last, middle, first) so collection order would fail — passing proves the
+    full chain was enforced.
+
+    ROBOT = robot fixture (isolated subprocess)  PLAIN = plain test (in-process)
+
+    numeric: first=order(1), middle=order(2), last=order(3)
+    after:   middle=order(after="test_first"), last=order(after="test_middle")
+    """
+    _make_robot_module(pytester)
+    _configure_isolated_plugin(pytester, parallelism=4)
+
+    def params(t):
+        return "(robot)" if t == "ROBOT" else "()"
+
+    if marker_style == "numeric":
+        first_mark = "@pytest.mark.order(1)\n"
+        middle_mark = "@pytest.mark.order(2)\n"
+        last_mark = "@pytest.mark.order(3)\n"
+    else:
+        first_mark = ""
+        middle_mark = '@pytest.mark.order(after="test_first")\n'
+        last_mark = '@pytest.mark.order(after="test_middle")\n'
+
+    pytester.makepyfile(test_order_sequence=f"""\
+import pathlib
+import pytest
+
+
+{last_mark}def test_last{params(last_type)}:
+    assert pathlib.Path("sentinel_2.txt").exists(), "test_middle must run before test_last"
+
+
+{middle_mark}def test_middle{params(middle_type)}:
+    assert pathlib.Path("sentinel_1.txt").exists(), "test_first must run before test_middle"
+    pathlib.Path("sentinel_2.txt").write_text("done")
+
+
+{first_mark}def test_first{params(first_type)}:
+    pathlib.Path("sentinel_1.txt").write_text("done")
+""")
+
+    result = pytester.runpytest_subprocess("-vv")
+    result.assert_outcomes(passed=3)
+
+
+@pytest.mark.parametrize(
+    "a_fixture, b_fixture",
+    [("robot", "robot"), ("robot", "")],
+    ids=["RR", "RN"],
+)
+def test_unordered_tests_still_run_in_parallel(pytester, a_fixture, b_fixture):
+    """
+    Tests WITHOUT @pytest.mark.order must not be serialised by order-marker
+    support.  With parallelism=2, two 1.5 s tests must overlap in wall-clock
+    time when the first test uses the robot fixture (starts async subprocess,
+    allowing the second test to run concurrently).
+
+    NR is omitted: a non-robot test runs in-process synchronously, so it
+    completes before the subsequent robot subprocess starts — serial by design.
+    """
+    _make_robot_module(pytester)
+    _configure_isolated_plugin(pytester, parallelism=2)
+
+    def params(f):
+        return f"({f})" if f else "()"
+
+    pytester.makepyfile(test_parallel_execution=f"""\
+import pathlib
+import time
+
+
+def test_a{params(a_fixture)}:
+    pathlib.Path("a_start.txt").write_text(str(time.monotonic()))
+    time.sleep(1.5)
+    pathlib.Path("a_end.txt").write_text(str(time.monotonic()))
+
+
+def test_b{params(b_fixture)}:
+    pathlib.Path("b_start.txt").write_text(str(time.monotonic()))
+    time.sleep(1.5)
+    pathlib.Path("b_end.txt").write_text(str(time.monotonic()))
+""")
+
+    result = pytester.runpytest_subprocess("-vv")
+    result.assert_outcomes(passed=2)
+
+    root = pathlib.Path(pytester.path)
+    a_end = float((root / "a_end.txt").read_text())
+    b_start = float((root / "b_start.txt").read_text())
+    assert (
+        b_start < a_end
+    ), f"Expected parallel: b_start={b_start:.3f} a_end={a_end:.3f}"


### PR DESCRIPTION
A more robust version of https://github.com/robotpy/pyfrc/pull/256.

-Thanks

-Mike